### PR TITLE
xterm 256 color

### DIFF
--- a/qmltermwidget/src/ksession.cpp
+++ b/qmltermwidget/src/ksession.cpp
@@ -74,7 +74,7 @@ Session *KSession::createSession(QString name)
     QString shellProg = envshell != NULL ? envshell : "/bin/bash";
     session->setProgram(shellProg);
 
-    setenv("TERM", "xterm", 1);
+    setenv("TERM", "xterm-256color", 1);
 
     //session->setProgram();
 


### PR DESCRIPTION
I think this is necessary, so that the terminal has rich colors and is not old-fashioned